### PR TITLE
[windows] Revisit compiler notation in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -828,6 +828,13 @@ function Get-PinnedToolchainVersion() {
   throw "PinnedVersion must be set"
 }
 
+$DriverBinaryCache = Get-HostProjectBinaryCache Driver
+$CompilersBinaryCache = if ($IsCrossCompiling) {
+  Get-BuildProjectBinaryCache Compilers
+} else {
+  Get-HostProjectBinaryCache Compilers
+}
+
 function Get-ClangDriverName([Platform] $Platform, [string] $Lang) {
   switch ($Platform) {
     Windows {
@@ -911,13 +918,6 @@ function Build-CMakeProject {
     if ($Platform -eq "Windows") {
       Invoke-VsDevShell $Arch
     }
-
-    $CompilersBinaryCache = if ($IsCrossCompiling) {
-      Get-BuildProjectBinaryCache Compilers
-    } else {
-      Get-HostProjectBinaryCache Compilers
-    }
-    $DriverBinaryCache = Get-HostProjectBinaryCache Driver
 
     if ($EnableCaching) {
       $env:SCCACHE_DIRECT = "true"
@@ -1439,11 +1439,6 @@ function Build-Compilers() {
   )
 
   Isolate-EnvVars {
-    $CompilersBinaryCache = if ($Build) {
-      Get-BuildProjectBinaryCache Compilers
-    } else {
-      Get-HostProjectBinaryCache Compilers
-    }
     $BuildTools = Join-Path -Path (Get-BuildProjectBinaryCache BuildTools) -ChildPath bin
 
     if ($TestClang -or $TestLLD -or $TestLLDB -or $TestLLVM -or $TestSwift) {
@@ -1794,12 +1789,6 @@ function Build-Runtime([Platform]$Platform, $Arch) {
 
   Isolate-EnvVars {
     $env:Path = "$(Get-CMarkBinaryCache $Arch)\src;$(Get-PinnedToolchainRuntime);${env:Path}"
-
-    $CompilersBinaryCache = if ($IsCrossCompiling) {
-      Get-BuildProjectBinaryCache Compilers
-    } else {
-      Get-HostProjectBinaryCache Compilers
-    }
 
     Build-CMakeProject `
       -Src $SourceCache\swift `

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1047,7 +1047,7 @@ function Build-CMakeProject {
       }
       Append-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
     }
-    if ($UseASMCompiler -eq [Compiler]::Pinned -Or $UseASMCompiler -eq [Compiler]::Built) {
+    if ($UseASMCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
       $Driver = (Get-ClangDriverName $Platform -Lang "ASM")
       TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER (Get-ToolchainTool -Compiler $UseASMCompiler -Name $Driver)
       Append-FlagsDefine $Defines CMAKE_ASM_FLAGS "--target=$($Arch.LLVMTarget)"
@@ -1055,7 +1055,7 @@ function Build-CMakeProject {
         TryAdd-KeyValue $Defines CMAKE_ASM_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY_MultiThreadedDLL "/MD"
       }
     }
-    if ($UseCCompiler -eq [Compiler]::Pinned -Or $UseCCompiler -eq [Compiler]::Built) {
+    if ($UseCCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
       $Driver = (Get-ClangDriverName $Platform -Lang "C")
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Get-ToolchainTool -Compiler $UseCCompiler -Name $Driver)
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER_TARGET $Arch.LLVMTarget
@@ -1070,7 +1070,7 @@ function Build-CMakeProject {
       }
       Append-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
     }
-    if ($UseCXXCompiler -eq [Compiler]::Pinned -Or $UseCXXCompiler -eq [Compiler]::Built) {
+    if ($UseCXXCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
       $Driver = (Get-ClangDriverName $Platform -Lang "CXX")
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Get-ToolchainTool -Compiler $UseCXXCompiler -Name $Driver)
       TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_TARGET $Arch.LLVMTarget
@@ -1085,7 +1085,7 @@ function Build-CMakeProject {
       }
       Append-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
     }
-    if ($UseSwiftCompiler -eq [Compiler]::Pinned -Or $UseSwiftCompiler -eq [Compiler]::Built) {
+    if ($UseSwiftCompiler -in @([Compiler]::Pinned, [Compiler]::Built)) {
       $SwiftArgs = @()
 
       if ($UseSwiftSwiftDriver) {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -828,6 +828,21 @@ function Get-PinnedToolchainVersion() {
   throw "PinnedVersion must be set"
 }
 
+function Get-ClangDriverName([Platform] $Platform, [string] $Lang) {
+  switch ($Platform) {
+    Windows {
+      "clang-cl.exe"
+    }
+    Android {
+      switch ($Lang) {
+        C { "clang.exe" }
+        ASM { "clang.exe" }
+        CXX { "clang++.exe" }
+      }
+    }
+  }
+}
+
 function TryAdd-KeyValue([hashtable]$Hashtable, [string]$Key, [string]$Value) {
   if (-not $Hashtable.Contains($Key)) {
     $Hashtable.Add($Key, $Value)
@@ -1010,7 +1025,7 @@ function Build-CMakeProject {
       Append-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
     }
     if ($UsePinnedCompilers.Contains("ASM") -Or $UseBuiltCompilers.Contains("ASM")) {
-      $Driver = if ($Platform -eq "Windows") { "clang-cl.exe" } else { "clang.exe" }
+      $Driver = (Get-ClangDriverName $Platform -Lang "ASM")
       if ($UseBuiltCompilers.Contains("ASM")) {
         TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
       } else {
@@ -1022,7 +1037,7 @@ function Build-CMakeProject {
       }
     }
     if ($UsePinnedCompilers.Contains("C") -Or $UseBuiltCompilers.Contains("C")) {
-      $Driver = if ($Platform -eq "Windows") { "clang-cl.exe" } else { "clang.exe" }
+      $Driver = (Get-ClangDriverName $Platform -Lang "C")
       if ($UseBuiltCompilers.Contains("C")) {
         TryAdd-KeyValue $Defines CMAKE_C_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
       } else {
@@ -1041,7 +1056,7 @@ function Build-CMakeProject {
       Append-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
     }
     if ($UsePinnedCompilers.Contains("CXX") -Or $UseBuiltCompilers.Contains("CXX")) {
-      $Driver = if ($Platform -eq "Windows") { "clang-cl.exe" } else { "clang++.exe" }
+      $Driver = (Get-ClangDriverName $Platform -Lang "CXX")
       if ($UseBuiltCompilers.Contains("CXX")) {
         TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
       } else {

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -800,11 +800,16 @@ function Fetch-Dependencies {
   }
 }
 
-function Get-PinnedToolchainTool() {
+function Get-PinnedToolchainTool([string] $Name) {
   if (Test-Path "$BinaryCache\toolchains\${PinnedToolchain}\LocalApp\Programs\Swift\Toolchains\$(Get-PinnedToolchainVersion)+Asserts\usr\bin") {
-    return "$BinaryCache\toolchains\${PinnedToolchain}\LocalApp\Programs\Swift\Toolchains\$(Get-PinnedToolchainVersion)+Asserts\usr\bin"
+    $Path = "$BinaryCache\toolchains\${PinnedToolchain}\LocalApp\Programs\Swift\Toolchains\$(Get-PinnedToolchainVersion)+Asserts\usr\bin"
+  } else {
+    $Path = "$BinaryCache\toolchains\${PinnedToolchain}\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin"
   }
-  return "$BinaryCache\toolchains\${PinnedToolchain}\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin"
+  if ($Name) {
+    $Path = "$Path\$Name"
+  }
+  return $Path
 }
 
 function Get-PinnedToolchainSDK() {
@@ -833,6 +838,10 @@ $CompilersBinaryCache = if ($IsCrossCompiling) {
   Get-BuildProjectBinaryCache Compilers
 } else {
   Get-HostProjectBinaryCache Compilers
+}
+
+function Get-BuiltToolchainTool([string] $Name) {
+  return if ($Name) { "$CompilersBinaryCache\bin\$Name" } else { "$CompilersBinaryCache\bin" }
 }
 
 function Get-ClangDriverName([Platform] $Platform, [string] $Lang) {
@@ -1004,7 +1013,7 @@ function Build-CMakeProject {
         # Use a built lld linker as the Android's NDK linker might be too
         # old and not support all required relocations needed by the Swift
         # runtime.
-        $ldPath = ([IO.Path]::Combine($CompilersBinaryCache, "bin", "ld.lld"))
+        $ldPath = (Get-BuiltToolchainTool "ld.lld")
         Append-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "--ld-path=$ldPath"
         Append-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "--ld-path=$ldPath"
       }
@@ -1027,9 +1036,9 @@ function Build-CMakeProject {
     if ($UsePinnedCompilers.Contains("ASM") -Or $UseBuiltCompilers.Contains("ASM")) {
       $Driver = (Get-ClangDriverName $Platform -Lang "ASM")
       if ($UseBuiltCompilers.Contains("ASM")) {
-        TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
+        TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER (Get-BuiltToolchainTool $Driver)
       } else {
-        TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath $Driver)
+        TryAdd-KeyValue $Defines CMAKE_ASM_COMPILER (Get-PinnedToolchainTool $Driver)
       }
       Append-FlagsDefine $Defines CMAKE_ASM_FLAGS "--target=$($Arch.LLVMTarget)"
       if ($Platform -eq "Windows") {
@@ -1039,9 +1048,9 @@ function Build-CMakeProject {
     if ($UsePinnedCompilers.Contains("C") -Or $UseBuiltCompilers.Contains("C")) {
       $Driver = (Get-ClangDriverName $Platform -Lang "C")
       if ($UseBuiltCompilers.Contains("C")) {
-        TryAdd-KeyValue $Defines CMAKE_C_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
+        TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Get-BuiltToolchainTool $Driver)
       } else {
-        TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath $Driver)
+        TryAdd-KeyValue $Defines CMAKE_C_COMPILER (Get-PinnedToolchainTool $Driver)
       }
       TryAdd-KeyValue $Defines CMAKE_C_COMPILER_TARGET $Arch.LLVMTarget
 
@@ -1058,9 +1067,9 @@ function Build-CMakeProject {
     if ($UsePinnedCompilers.Contains("CXX") -Or $UseBuiltCompilers.Contains("CXX")) {
       $Driver = (Get-ClangDriverName $Platform -Lang "CXX")
       if ($UseBuiltCompilers.Contains("CXX")) {
-        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", $Driver))
+        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Get-BuiltToolchainTool $Driver)
       } else {
-        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath $Driver)
+        TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER (Get-PinnedToolchainTool $Driver)
       }
       TryAdd-KeyValue $Defines CMAKE_CXX_COMPILER_TARGET $Arch.LLVMTarget
 
@@ -1080,9 +1089,9 @@ function Build-CMakeProject {
       if ($UseSwiftSwiftDriver) {
         TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER ([IO.Path]::Combine($DriverBinaryCache, "bin", "swiftc.exe"))
       } elseif ($UseBuiltCompilers.Contains("Swift")) {
-        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", "swiftc.exe"))
+        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER (Get-BuiltToolchainTool "swiftc.exe")
       } else {
-        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER (Join-Path -Path (Get-PinnedToolchainTool) -ChildPath  "swiftc.exe")
+        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER (Get-PinnedToolchainTool "swiftc.exe")
       }
       if (-not ($Platform -eq "Windows")) {
         TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER_WORKS = "YES"

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -833,7 +833,6 @@ function Get-PinnedToolchainVersion() {
   throw "PinnedVersion must be set"
 }
 
-$DriverBinaryCache = Get-HostProjectBinaryCache Driver
 $CompilersBinaryCache = if ($IsCrossCompiling) {
   Get-BuildProjectBinaryCache Compilers
 } else {
@@ -941,8 +940,9 @@ function Build-CMakeProject {
     }
 
     # TODO(compnerd) workaround swiftc.exe symlink not existing.
+    $DriverToolDir = "$(Get-HostProjectBinaryCache Driver)\bin"
     if ($UseSwiftSwiftDriver) {
-      Copy-Item -Force ([IO.Path]::Combine($DriverBinaryCache, "bin", "swift-driver.exe")) ([IO.Path]::Combine($DriverBinaryCache, "bin", "swiftc.exe"))
+      Copy-Item -Force "$DriverToolDir\swift-driver.exe" "$DriverToolDir\swiftc.exe"
     }
 
     # Add additional defines (unless already present)
@@ -1087,7 +1087,7 @@ function Build-CMakeProject {
       $SwiftArgs = @()
 
       if ($UseSwiftSwiftDriver) {
-        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER ([IO.Path]::Combine($DriverBinaryCache, "bin", "swiftc.exe"))
+        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER "$DriverToolDir\swiftc.exe"
       } elseif ($UseBuiltCompilers.Contains("Swift")) {
         TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER (Get-BuiltToolchainTool "swiftc.exe")
       } else {


### PR DESCRIPTION
Some of the complexity in `Build-CMakeProject` seems to originate from the way we specify which languages (`C`, `CXX`, `ASM`, `Swift`) and compilers (MSVC, Pinned, Just-Built, NDK) should be used. A language is present in the build, if it has a compiler assigned, but it cannot have more than one. The current abstraction, doesn't reflect that: languages could appear multiple times in `UseXYCompilers`. If we change that, we might be able to simplify the implementation.